### PR TITLE
Show metabox on multiple post-type

### DIFF
--- a/classes/metabox.class.php
+++ b/classes/metabox.class.php
@@ -51,9 +51,7 @@ class CSFramework_Metabox extends CSFramework_Abstract{
   public function add_meta_box( $post_type ) {
 
     foreach ( $this->options as $value ) {
-      if( $post_type == $value['post_type'] ) {
-        add_meta_box( $value['id'], $value['title'], array( &$this, 'render_meta_box_content' ), $value['post_type'], $value['context'], $value['priority'], $value );
-      }
+      add_meta_box( $value['id'], $value['title'], array( &$this, 'render_meta_box_content' ), $value['post_type'], $value['context'], $value['priority'], $value );
     }
 
   }


### PR DESCRIPTION
As WP 4.4.0 say: The `$screen` parameter now accepts an array of screen IDs.

Remove check post_type allow set $screen as array.