### PR TITLE
Debug Light added

### DIFF
--- a/classes/options.class.php
+++ b/classes/options.class.php
@@ -144,6 +144,18 @@ abstract class CSFramework_Options extends CSFramework_Abstract {
       $out .= "</pre>";
 
     }
+    
+    if( ( isset( $this->field['debug_light'] ) && $this->field['debug_light'] === true ) || ( defined( 'CS_OPTIONS_DEBUG_LIGHT' ) && CS_OPTIONS_DEBUG_LIGHT ) ) {
+
+      $value = $this->element_value();
+
+      $out .= "<pre>";
+      $out .= "<strong>". __( 'USAGE', 'cs-framework' ) .":</strong>";
+      $out .= "\n";
+      $out .= ( isset( $this->field['id'] ) ) ? "cs_get_option( '". $this->field['id'] ."' );" : '';
+      $out .= "</pre>";
+
+    }
 
     return $out;
 


### PR DESCRIPTION
Debug Light to show only values for quick copy paste. 
Reference Discussion: #282 

Thoughts? 

I think `CS_OPTIONS_DEBUG` (CONFIG DATA) takes up too much space in the settings page when you just want the values to copy and paste in into plugin or theme php files. The config data can make the pages really long, when you need a small piece of information. 

Debug Light screenshot @ http://take.ms/nYabW

![image](https://cloud.githubusercontent.com/assets/6123260/14434039/debe6906-ffde-11e5-8ce9-9fefcadc74da.png)

Compare Full Debug screenshot @http://take.ms/XKmvl

![image](https://cloud.githubusercontent.com/assets/6123260/14434355/539d471e-ffe0-11e5-81b9-c6e43f1a075d.png)