### PR TITLE
Debug Light with ID field below USAGE

### DIFF
--- a/classes/options.class.php
+++ b/classes/options.class.php
@@ -144,6 +144,18 @@ abstract class CSFramework_Options extends CSFramework_Abstract {
       $out .= "</pre>";
 
     }
+    
+    if( ( isset( $this->field['debug_light'] ) && $this->field['debug_light'] === true ) || ( defined( 'CS_OPTIONS_DEBUG_LIGHT' ) && CS_OPTIONS_DEBUG_LIGHT ) ) {
+
+      $value = $this->element_value();
+
+      $out .= "<pre>";
+      $out .= "<strong>". __( 'USAGE', 'cs-framework' ) .":</strong>";
+      $out .= "\n";
+      $out .= ( isset( $this->field['id'] ) ) ? "cs_get_option( '". $this->field['id'] ."' );" : '';
+      $out .= "</pre>";
+
+    }
 
     return $out;
 

--- a/classes/options.class.php
+++ b/classes/options.class.php
@@ -153,6 +153,10 @@ abstract class CSFramework_Options extends CSFramework_Abstract {
       $out .= "<strong>". __( 'USAGE', 'cs-framework' ) .":</strong>";
       $out .= "\n";
       $out .= ( isset( $this->field['id'] ) ) ? "cs_get_option( '". $this->field['id'] ."' );" : '';
+      $out .= "\n";
+      $out .= "<strong>". __( 'ID', 'cs-framework' ) .":</strong>";
+      $out .= "\n";
+      $out .= ( isset( $this->field['id'] ) ) ? "". $this->field['id'] ."" : '';
       $out .= "</pre>";
 
     }


### PR DESCRIPTION
Updated Debug Light to include ID only below Usage info. 

So now Debug Light shows.. 

USAGE: 
`cs_get_option('field_id');`
ID:
`field_id`

Sometimes the `cs_get_option`'s are already set up and I just need the ID's. This will allow to triple click just the ID to easily copy paste. This way the user doesn't have to highlight part of `cs_get_option`. 

**New screenshot @ http://take.ms/ky2Nl**

![image](https://cloud.githubusercontent.com/assets/6123260/14435020/cb413d54-ffe3-11e5-9207-15a9f5c1238e.png)

**Zoomed In @ http://take.ms/CXQCZ**

![image](https://cloud.githubusercontent.com/assets/6123260/14435315/4cc42c78-ffe5-11e5-8c75-b615aefc3af8.png)


**Compare to old screenshot @ http://take.ms/nYabW**

![image](https://cloud.githubusercontent.com/assets/6123260/14435049/ebf4fd06-ffe3-11e5-9a28-df03bc3c3bb4.png)