### PR TITLE
Added Support for WP Nav Menus!

### DIFF
--- a/classes/options.class.php
+++ b/classes/options.class.php
@@ -290,6 +290,20 @@ abstract class CSFramework_Options extends CSFramework_Abstract {
         }
 
       break;
+      
+      // Support WordPress Nav Menus
+      case 'menus':
+      case 'menu':
+
+        $menus = get_terms( 'nav_menu' );
+
+        if ( ! is_wp_error( $menus ) && ! empty( $menus ) ) {
+          foreach ( $menus as $menu ) {
+            $options[$menu->term_id] = $menu->name;
+          }
+        }
+
+      break;
 
       case 'custom':
       case 'callback':


### PR DESCRIPTION
```php
array(
  'id'         => 'choose_menu',
  'type'       => 'select',
  'title'      => __( 'Choose Menu', 'cs-framework' ),
  'info'      => __( 'Choose custom menus for this page.', 'cs-framework' ),
  'options'    => 'menus',
  'default_option' => __('Select your menu', 'cs-framework'),
),
```