### PR TITLE
Small change

### DIFF
--- a/_framework_api/options/notice.md
+++ b/_framework_api/options/notice.md
@@ -8,7 +8,7 @@ filename: options/notice.md
 ```php?start_inline=1
 array(
   'type'    => 'notice',
-  'class'   => 'Success',
+  'class'   => 'success',
   'content' => 'Success: Lorem Ipsum Dollar.',
 ),
 ```


### PR DESCRIPTION
Bug solved. The capital class name will not work.
History - I copied this code and it was not working. I found that the CSS class latter is in uppercase. I made it lowercase and it starts working.