### PR TITLE
Update cs-framework-path.php for constant access

### DIFF
--- a/cs-framework-path.php
+++ b/cs-framework-path.php
@@ -7,9 +7,15 @@
  * @version 1.0.0
  *
  */
-defined( 'CS_VERSION' )    or  define( 'CS_VERSION',    '1.0.1' );
-defined( 'CS_OPTION' )     or  define( 'CS_OPTION',     '_cs_options' );
-defined( 'CS_CUSTOMIZE' )  or  define( 'CS_CUSTOMIZE',  '_cs_customize_options' );
+add_action( 'init', 'cs_define_init', 2 );
+if( ! function_exists( 'cs_define_init' ) ) {
+	function cs_define_init() {
+		defined( 'CS_VERSION' )    or  define( 'CS_VERSION',    '1.0.1' );
+		defined( 'CS_OPTION' )     or  define( 'CS_OPTION',     '_cs_options' );
+		defined( 'CS_CUSTOMIZE' )  or  define( 'CS_CUSTOMIZE',  '_cs_customize_options' );
+	}
+}
+
 
 /**
  *


### PR DESCRIPTION
This is for we can  use this as plugin and also can override the CS_OPTION and CS_CUSTOMIZE constant via our theme code. I started discussion here:
https://github.com/Codestar/codestar-framework/issues/384

I think this is proper solution for this. So we can override it via our theme code like this:

```
add_action( 'init', 'theme_define_init', 1 );
if( ! function_exists( 'theme_define_init' ) ) {
function theme_define_init() {
	defined( 'CS_VERSION' )    or  define( 'CS_VERSION',    '1.0.1' );
	defined( 'CS_OPTION' )     or  define( 'CS_OPTION',     'mytheme_theme_options' );
	defined( 'CS_CUSTOMIZE' )  or  define( 'CS_CUSTOMIZE',  'mytheme_theme_customize_options' );
}
}
```



