### PR TITLE
Repeater: Check if value passed is actually an array

### DIFF
--- a/fields/repeater/repeater.php
+++ b/fields/repeater/repeater.php
@@ -55,7 +55,7 @@ if( ! class_exists( 'CSF_Field_repeater' ) ) {
 
         echo '<div class="csf-repeater-wrapper csf-data-wrapper" data-unique-id="'. $this->unique .'" data-field-id="['. $this->field['id'] .']" data-max="'. $args['max'] .'" data-min="'. $args['min'] .'">';
 
-        if( ! empty( $this->value ) ) {
+        if( ! empty( $this->value ) && is_array( $this->value ) ) {
 
           $num = 0;
 


### PR DESCRIPTION
On some occasions, when changing the type of the field to a repeater, the value comes from the database.
So, it will pass the `empty()` check and will throw a notice on the `foreach` just after this.

This code change will add another check to make sure its an array.