### PR TITLE
Fixed admin enqueue assets

### DIFF
--- a/classes/setup.class.php
+++ b/classes/setup.class.php
@@ -450,7 +450,7 @@ if ( ! class_exists( 'CSF' ) ) {
 
       if ( ! empty( self::$args['taxonomy_options'] ) ) {
         foreach ( self::$args['taxonomy_options'] as $argument ) {
-          if ( $wpscreen->taxonomy === $argument['taxonomy'] ) {
+          if ( in_array( $wpscreen->taxonomy, (array) $argument['taxonomy'] ) ) {
             $enqueue = true;
           }
         }


### PR DESCRIPTION
Hi,

I'm using the Pro version of the CodeStar framework & I've noticed that the admin assets do not load while I use a meta box for multiple taxonomies. Please check this screenshot https://prnt.sc/10qwpea

The condition should be like assigning a metabox for multiple post types. Like this way: https://prnt.sc/10qwylf

Hopefully, you will review & accept my pull request & also fix it into the PRO version.

Kind Wishes,
Alberuni Azad