### PR TITLE
Allow codestart to be used as a lib

### DIFF
--- a/codestar-framework.php
+++ b/codestar-framework.php
@@ -1,4 +1,4 @@
-<?php if ( ! defined( 'ABSPATH' ) ) { die; } // Cannot access directly.
+<?php if ( ! defined( 'ABSPATH' ) ) { return; } // Cannot access directly.
 /**
  *
  * @package   Codestar Framework - WordPress Options Framework


### PR DESCRIPTION
When including it as a lib, running it for tests where WP ABSPATH isn't set yet, will terminate the run.

This can happen using composer and running phpcs for example.