### PR TITLE
PHP 8.3 Deprecated issue fixed

### DIFF
--- a/classes/fields.class.php
+++ b/classes/fields.class.php
@@ -10,6 +10,12 @@
 if ( ! class_exists( 'CSF_Fields' ) ) {
   abstract class CSF_Fields extends CSF_Abstract {
 
+    public $field;
+    public $value;
+    public $unique;
+    public $where;
+    public $parent;
+    
     public function __construct( $field = array(), $value = '', $unique = '', $where = '', $parent = '' ) {
       $this->field  = $field;
       $this->value  = $value;


### PR DESCRIPTION
Deprecated: Creation of dynamic property CSF_Field_select::$field is deprecated in framework\classes\fields.class.php on line 15

Deprecated: Creation of dynamic property CSF_Field_select::$value is deprecated in framework\classes\fields.class.php on line 16

Deprecated: Creation of dynamic property CSF_Field_select::$unique is deprecated in framework\classes\fields.class.php on line 17

Deprecated: Creation of dynamic property CSF_Field_select::$where is deprecated in framework\classes\fields.class.php on line 18

Deprecated: Creation of dynamic property CSF_Field_select::$parent is deprecated in framework\classes\fields.class.php on line 19